### PR TITLE
Updated OAuth Scopes

### DIFF
--- a/qr-code/appsscript.json
+++ b/qr-code/appsscript.json
@@ -5,8 +5,8 @@
   "exceptionLogging": "STACKDRIVER",
   "oauthScopes": [
     "https://www.googleapis.com/auth/documents.currentonly",
-    "https://www.googleapis.com/auth/presentations", 
-    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/presentations.currentonly", 
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/gmail.addons.execute",
     "https://www.googleapis.com/auth/gmail.addons.current.action.compose"


### PR DESCRIPTION
Since the add-on only requires access to the current document or sheet, we can do with more-restricted scopes.