### PR TITLE
lorem-ipsum: Add loripsum.net to whitelist

### DIFF
--- a/apps-script/lorem-ipsum/appsscript.json
+++ b/apps-script/lorem-ipsum/appsscript.json
@@ -13,7 +13,8 @@
   ],
   "runtimeVersion": "V8",
   "urlFetchWhitelist": [
-    "https://api.qrserver.com/"
+    "https://api.qrserver.com/",
+    "https://loripsum.net/api/"
   ],
   "addOns": {
     "common": {


### PR DESCRIPTION
https://loripsum.net/api/ needs to be added to urlFetchWhitelist in manifest